### PR TITLE
Add libftdi build and add mingw64 build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian
+
+RUN apt-get update && apt-get install -y gcc-mingw-w64-i686 g++-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 libtool pkg-config bzip2 zip make autoconf wget patch git automake flex bison cmake xsltproc && rm -rf /var/lib/apt/lists/*
+
+COPY . /avrdude-build-script
+
+WORKDIR /avrdude-build-script
+
+ENTRYPOINT ["/avrdude-build-script/package-avrdude.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian
 
-RUN apt-get update && apt-get install -y gcc-mingw-w64-i686 g++-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 libtool pkg-config bzip2 zip make autoconf wget patch git automake flex bison cmake xsltproc && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y gcc-mingw-w64-i686 g++-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 libtool pkg-config bzip2 zip make autoconf gperf wget patch git gcc g++ automake flex bison cmake xsltproc && rm -rf /var/lib/apt/lists/*
 
 COPY . /avrdude-build-script
 

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,22 @@ Just run:
 Setup has been done on partially set up development machines.
 If you find any package missing from the following list, please open an issue at once!
 
+### Docker Building
+
+Run:
+```
+mkdir dist
+docker build . -t avrdude-builder
+# cross compile i686
+docker run --rm -it -v $PWD/dist:/avrdude-build-script/dist -e CROSS_COMPILE=mingw avrdude-builder
+# cross compile x86_64
+docker run --rm -it -v $PWD/dist:/avrdude-build-script/dist -e CROSS_COMPILE=mingw64 avrdude-builder
+# remove container
+docker rmi avrdude-builder
+```
+
+If you do not need cross compile, just remove `-e CROSS_COMPILE=mingw`.
+
 #### Debian requirements
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ sudo apt-get install gcc-mingw-w64-i686
 When building you must set the env var `CROSS_COMPILE` to `mingw` for example:
 
 ```
-CROSS_COMPILE=mingw ./package_avrdude.bash
+CROSS_COMPILE=mingw ./package-avrdude.bash
 ```
 
 cross compile with mingw has been tested on Ubuntu 14.04 (mingw-w64 4.8), different versions of mingw may behave differently and fail to build.

--- a/avrdude-6.3-patches/01-fix_ftdi_read_data_segfault_bugs.patch
+++ b/avrdude-6.3-patches/01-fix_ftdi_read_data_segfault_bugs.patch
@@ -1,0 +1,28 @@
+diff -Naur a/ft245r.c b/ft245r.c
+--- a/ft245r.c	2014-09-16 03:01:09.000000000 +0800
++++ b/ft245r.c	2020-02-22 21:00:23.381036600 +0800
+@@ -653,14 +653,22 @@
+ 
+ 
+ static void ft245r_close(PROGRAMMER * pgm) {
++    int retry_times = 0;
+     if (handle) {
+         // I think the switch to BB mode and back flushes the buffer.
+         ftdi_set_bitmode(handle, 0, BITMODE_SYNCBB); // set Synchronous BitBang, all in puts
+         ftdi_set_bitmode(handle, 0, BITMODE_RESET); // disable Synchronous BitBang
+         ftdi_usb_close(handle);
+-        ftdi_deinit (handle);
+-        pthread_cancel(readerthread);
++        while(pthread_cancel(readerthread) && retry_times < 100) {
++            retry_times++;
++            usleep(100);
++        }
++        if (retry_times >= 100) {
++            avrdude_message(MSG_INFO, "Too many retry to close reader thread\n");
++        }
++
+         pthread_join(readerthread, NULL);
++        ftdi_deinit (handle);
+         free(handle);
+         handle = NULL;
+     }

--- a/avrdude-6.3.build.bash
+++ b/avrdude-6.3.build.bash
@@ -20,6 +20,7 @@ cd objdir
 PREFIX=`pwd`
 cd -
 
+rm -rf avrdude-6.3
 git clone https://github.com/facchinm/avrdude.git avrdude-6.3 --depth 1
 
 cd avrdude-6.3
@@ -42,6 +43,11 @@ COMMON_FLAGS=""
 if [[ $CROSS_COMPILE == "mingw" ]] ; then
 CFLAGS="-DHAVE_LIBHIDAPI $CFLAGS"
 LIBS="-lhidapi -lsetupapi"
+fi
+
+if [[ $OS == "Msys" ]] ; then
+  CFLAGS="-DHAVE_LIBHIDAPI $CFLAGS"
+  LIBS="-lhidapi -lsetupapi -Wl,-Bstatic -lwinpthread"
 fi
 
 if [[ $OS == "Darwin" ]] ; then

--- a/avrdude-6.3.build.bash
+++ b/avrdude-6.3.build.bash
@@ -42,7 +42,7 @@ COMMON_FLAGS=""
 
 if [[ $CROSS_COMPILE == "mingw" ]] ; then
 CFLAGS="-DHAVE_LIBHIDAPI $CFLAGS"
-LIBS="-lhidapi -lsetupapi"
+LIBS="-lhidapi -lsetupapi -Wl,-Bstatic -lwinpthread"
 fi
 
 if [[ $OS == "Msys" ]] ; then

--- a/avrdude-6.3.build.bash
+++ b/avrdude-6.3.build.bash
@@ -40,12 +40,7 @@ fi
 
 COMMON_FLAGS=""
 
-if [[ $CROSS_COMPILE == "mingw" ]] ; then
-CFLAGS="-DHAVE_LIBHIDAPI $CFLAGS"
-LIBS="-lhidapi -lsetupapi -Wl,-Bstatic -lwinpthread"
-fi
-
-if [[ $OS == "Msys" ]] ; then
+if [[ $CROSS_COMPILE == "mingw" || $CROSS_COMPILE == "mingw64" || $OS == "Msys" ]] ; then
   CFLAGS="-DHAVE_LIBHIDAPI $CFLAGS"
   LIBS="-lhidapi -lsetupapi -Wl,-Bstatic -lwinpthread"
 fi

--- a/avrdude-6.3.build.bash
+++ b/avrdude-6.3.build.bash
@@ -25,6 +25,7 @@ git clone https://github.com/facchinm/avrdude.git avrdude-6.3 --depth 1
 cd avrdude-6.3
 
 patch -p1 < ../avrdude-6.3-patches/90*
+patch -p1 < ../avrdude-6.3-patches/01-fix_ftdi_read_data_segfault_bugs.patch
 
 export CFLAGS="-I$PREFIX/include -I$PREFIX/include/hidapi -I$PREFIX/include/libelf -I$PREFIX/include/ncurses -I$PREFIX/include/ncursesw -I$PREFIX/include/readline -I$PREFIX/include/libusb-1.0 $CFLAGS"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"

--- a/libftdi-1.4.build.bash
+++ b/libftdi-1.4.build.bash
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+# Copyright (c) 2014-2016 Arduino LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+mkdir -p objdir
+cd objdir
+PREFIX=`pwd`
+cd -
+
+if [[ ! -f libftdi1-1.4.tar.bz2  ]] ;
+then
+	wget https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.4.tar.bz2
+fi
+
+tar xfv libftdi1-1.4.tar.bz2
+
+rm -rf libftdi1-1.4/build
+mkdir libftdi1-1.4/build
+
+cd libftdi1-1.4/
+if [[ $OS == "Msys" ]] ; then
+  patch -p1 < ../libftdi1-1.4-patches/01-add_sharedlibs_flag.patch
+fi
+cd build/
+
+CMAKE_EXTRA_FLAG=""
+
+if [[ $OS == "Msys" ]] ; then
+  CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DBUILD_TESTS=OFF -DSHAREDLIBS=OFF"
+fi
+
+cmake $CMAKE_EXTRA_FLAG -DCMAKE_INSTALL_PREFIX="$PREFIX" -DLIBUSB_INCLUDE_DIR="$PREFIX/include/libusb-1.0" -DLIBFTDI_LIBRARY_DIRS="$PREFIX/lib" -DLIBUSB_LIBRARIES="usb-1.0" ../
+make -j 1
+make install
+cd ../..
+

--- a/libftdi-1.4.build.bash
+++ b/libftdi-1.4.build.bash
@@ -36,8 +36,12 @@ cd build/
 
 CMAKE_EXTRA_FLAG="-DSHAREDLIBS=OFF -DBUILD_TESTS=OFF"
 
-if [[ $OS == "GNU/Linux"  ]] ; then
+if [[ $OS == "GNU/Linux" && $CROSS_COMPILE == "mingw" ]] ; then
   CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DCMAKE_TOOLCHAIN_FILE=./cmake/Toolchain-i686-w64-mingw32.cmake"
+fi
+
+if [[ $OS == "GNU/Linux" && $CROSS_COMPILE == "mingw64" ]] ; then
+  CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DCMAKE_TOOLCHAIN_FILE=./cmake/Toolchain-x86_64-w64-mingw32.cmake"
 fi
 
 cmake $CMAKE_EXTRA_FLAG -DCMAKE_INSTALL_PREFIX="$PREFIX" -DLIBUSB_INCLUDE_DIR="$PREFIX/include/libusb-1.0" -DLIBFTDI_LIBRARY_DIRS="$PREFIX/lib" -DLIBUSB_LIBRARIES="usb-1.0" ../

--- a/libftdi-1.4.build.bash
+++ b/libftdi-1.4.build.bash
@@ -31,15 +31,13 @@ rm -rf libftdi1-1.4/build
 mkdir libftdi1-1.4/build
 
 cd libftdi1-1.4/
-if [[ $OS == "Msys" ]] ; then
-  patch -p1 < ../libftdi1-1.4-patches/01-add_sharedlibs_flag.patch
-fi
+patch -p1 < ../libftdi1-1.4-patches/01-add_sharedlibs_flag.patch
 cd build/
 
-CMAKE_EXTRA_FLAG=""
+CMAKE_EXTRA_FLAG="-DSHAREDLIBS=OFF -DBUILD_TESTS=OFF"
 
-if [[ $OS == "Msys" ]] ; then
-  CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DBUILD_TESTS=OFF -DSHAREDLIBS=OFF"
+if [[ $OS == "GNU/Linux"  ]] ; then
+  CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DCMAKE_TOOLCHAIN_FILE=./cmake/Toolchain-i686-w64-mingw32.cmake"
 fi
 
 cmake $CMAKE_EXTRA_FLAG -DCMAKE_INSTALL_PREFIX="$PREFIX" -DLIBUSB_INCLUDE_DIR="$PREFIX/include/libusb-1.0" -DLIBFTDI_LIBRARY_DIRS="$PREFIX/lib" -DLIBUSB_LIBRARIES="usb-1.0" ../

--- a/libftdi1-1.4-patches/01-add_sharedlibs_flag.patch
+++ b/libftdi1-1.4-patches/01-add_sharedlibs_flag.patch
@@ -1,0 +1,180 @@
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2020-03-07 12:26:19.922659700 +0800
++++ b/CMakeLists.txt	2020-03-07 15:11:57.839140900 +0800
+@@ -46,6 +46,7 @@
+ set(CPACK_COMPONENT_STATICLIBS_GROUP "Development")
+ set(CPACK_COMPONENT_HEADERS_GROUP    "Development")
+ 
++option ( SHAREDLIBS "Build ㄎ libraries" ON )
+ option ( STATICLIBS "Build static libraries" ON )
+ 
+ # guess LIB_SUFFIX, don't take debian multiarch into account 
+diff -Naur a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+--- a/examples/CMakeLists.txt	2020-03-07 12:26:20.208196700 +0800
++++ b/examples/CMakeLists.txt	2020-03-07 15:18:03.493009700 +0800
+@@ -8,29 +8,31 @@
+ 
+     message(STATUS "Building example programs.")
+ 
+-    # Targets
+-    add_executable(simple simple.c)
+-    add_executable(bitbang bitbang.c)
+-    add_executable(bitbang2 bitbang2.c)
+-    add_executable(bitbang_cbus bitbang_cbus.c)
+-    add_executable(bitbang_ft2232 bitbang_ft2232.c)
+-    add_executable(find_all find_all.c)
+-    add_executable(serial_test serial_test.c)
+-    add_executable(baud_test baud_test.c)
+-    add_executable(stream_test stream_test.c)
+-    add_executable(eeprom eeprom.c)
+-
+-    # Linkage
+-    target_link_libraries(simple ftdi1)
+-    target_link_libraries(bitbang ftdi1)
+-    target_link_libraries(bitbang2 ftdi1)
+-    target_link_libraries(bitbang_cbus ftdi1)
+-    target_link_libraries(bitbang_ft2232 ftdi1)
+-    target_link_libraries(find_all ftdi1)
+-    target_link_libraries(serial_test ftdi1)
+-    target_link_libraries(baud_test ftdi1)
+-    target_link_libraries(stream_test ftdi1)
+-    target_link_libraries(eeprom ftdi1)
++    if ( SHAREDLIBS )
++        # Targets
++        add_executable(simple simple.c)
++        add_executable(bitbang bitbang.c)
++        add_executable(bitbang2 bitbang2.c)
++        add_executable(bitbang_cbus bitbang_cbus.c)
++        add_executable(bitbang_ft2232 bitbang_ft2232.c)
++        add_executable(find_all find_all.c)
++        add_executable(serial_test serial_test.c)
++        add_executable(baud_test baud_test.c)
++        add_executable(stream_test stream_test.c)
++        add_executable(eeprom eeprom.c)
++
++        # Linkage
++        target_link_libraries(simple ftdi1)
++        target_link_libraries(bitbang ftdi1)
++        target_link_libraries(bitbang2 ftdi1)
++        target_link_libraries(bitbang_cbus ftdi1)
++        target_link_libraries(bitbang_ft2232 ftdi1)
++        target_link_libraries(find_all ftdi1)
++        target_link_libraries(serial_test ftdi1)
++        target_link_libraries(baud_test ftdi1)
++        target_link_libraries(stream_test ftdi1)
++        target_link_libraries(eeprom ftdi1)
++    endif()
+ 
+     # libftdi++ examples
+     if(FTDI_BUILD_CPP)
+@@ -39,11 +41,13 @@
+             include_directories(BEFORE ${CMAKE_SOURCE_DIR}/ftdipp
+                                 ${Boost_INCLUDE_DIRS})
+ 
+-            # Target
+-            add_executable(find_all_pp find_all_pp.cpp)
+-
+-            # Linkage
+-            target_link_libraries(find_all_pp ftdipp1)
++            if ( SHAREDLIBS )
++                # Target
++                add_executable(find_all_pp find_all_pp.cpp)
++
++                # Linkage
++                target_link_libraries(find_all_pp ftdipp1)
++            endif()
+         endif(Boost_FOUND)
+     endif(FTDI_BUILD_CPP)
+ 
+diff -Naur a/ftdipp/CMakeLists.txt b/ftdipp/CMakeLists.txt
+--- a/ftdipp/CMakeLists.txt	2020-03-07 12:26:20.229190200 +0800
++++ b/ftdipp/CMakeLists.txt	2020-03-07 15:13:30.150838600 +0800
+@@ -22,25 +22,26 @@
+ 
+     set(FTDI_BUILD_CPP True PARENT_SCOPE)
+     message(STATUS "Building libftdi1++")
+-
+-    # Shared library
+-    add_library(ftdipp1 SHARED ${cpp_sources})
+-
+-    math(EXPR VERSION_FIXUP "${MAJOR_VERSION} + 1")    # Compatiblity with previous releases
+-    set_target_properties(ftdipp1 PROPERTIES VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 3)
+-
+-    # Prevent clobbering each other during the build
+-    set_target_properties(ftdipp1 PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+-
+-    # Dependencies
+-    target_link_libraries(ftdipp1 ftdi1 ${LIBUSB_LIBRARIES} ${BOOST_LIBRARIES})
+-
+-    
+-    install ( TARGETS ftdipp1
+-              RUNTIME DESTINATION bin
+-              LIBRARY DESTINATION lib${LIB_SUFFIX}
+-              ARCHIVE DESTINATION lib${LIB_SUFFIX}
+-            )
++    if ( SHAREDLIBS )
++      # Shared library
++      add_library(ftdipp1 SHARED ${cpp_sources})
++
++      math(EXPR VERSION_FIXUP "${MAJOR_VERSION} + 1")    # Compatiblity with previous releases
++      set_target_properties(ftdipp1 PROPERTIES VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 3)
++
++      # Prevent clobbering each other during the build
++      set_target_properties(ftdipp1 PROPERTIES CLEAN_DIRECT_OUTPUT 1)
++
++      # Dependencies
++      target_link_libraries(ftdipp1 ftdi1 ${LIBUSB_LIBRARIES} ${BOOST_LIBRARIES})
++
++      
++      install ( TARGETS ftdipp1
++                RUNTIME DESTINATION bin
++                LIBRARY DESTINATION lib${LIB_SUFFIX}
++                ARCHIVE DESTINATION lib${LIB_SUFFIX}
++              )
++    endif ()
+             
+     # Static library
+     if ( STATICLIBS )
+diff -Naur a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt	2020-03-07 12:26:20.257181000 +0800
++++ b/src/CMakeLists.txt	2020-03-07 15:13:02.108714300 +0800
+@@ -21,22 +21,24 @@
+ set(c_sources     ${CMAKE_CURRENT_SOURCE_DIR}/ftdi.c ${CMAKE_CURRENT_SOURCE_DIR}/ftdi_stream.c CACHE INTERNAL "List of c sources" )
+ set(c_headers     ${CMAKE_CURRENT_SOURCE_DIR}/ftdi.h CACHE INTERNAL "List of c headers" )
+ 
+-add_library(ftdi1 SHARED ${c_sources})
++if ( SHAREDLIBS )
++  add_library(ftdi1 SHARED ${c_sources})
+ 
+-math(EXPR VERSION_FIXUP "${MAJOR_VERSION} + 1")    # Compatiblity with previous releases
+-set_target_properties(ftdi1 PROPERTIES VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 2)
+-# Prevent clobbering each other during the build
+-set_target_properties ( ftdi1 PROPERTIES CLEAN_DIRECT_OUTPUT 1 )
+-
+-
+-# Dependencies
+-target_link_libraries(ftdi1 ${LIBUSB_LIBRARIES})
+-
+-install ( TARGETS ftdi1
+-          RUNTIME DESTINATION bin
+-          LIBRARY DESTINATION lib${LIB_SUFFIX}
+-          ARCHIVE DESTINATION lib${LIB_SUFFIX}
+-        )
++  math(EXPR VERSION_FIXUP "${MAJOR_VERSION} + 1")    # Compatiblity with previous releases
++  set_target_properties(ftdi1 PROPERTIES VERSION ${VERSION_FIXUP}.${MINOR_VERSION}.0 SOVERSION 2)
++  # Prevent clobbering each other during the build
++  set_target_properties ( ftdi1 PROPERTIES CLEAN_DIRECT_OUTPUT 1 )
++
++
++  # Dependencies
++  target_link_libraries(ftdi1 ${LIBUSB_LIBRARIES})
++
++  install ( TARGETS ftdi1
++            RUNTIME DESTINATION bin
++            LIBRARY DESTINATION lib${LIB_SUFFIX}
++            ARCHIVE DESTINATION lib${LIB_SUFFIX}
++          )
++endif ()
+ 
+ if ( STATICLIBS )
+   add_library(ftdi1-static STATIC ${c_sources})

--- a/libncurses-5.9.build.bash
+++ b/libncurses-5.9.build.bash
@@ -20,7 +20,7 @@ cd objdir
 PREFIX=`pwd`
 cd -
 
-if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw32"  || $CROSS_COMPILE_HOST == "aarch64-linux-gnu" ]] ; then
+if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw32" || $CROSS_COMPILE_HOST == "x86_64-w64-mingw32" || $CROSS_COMPILE_HOST == "aarch64-linux-gnu" ]] ; then
 	#Avoid compiling ncurses in Windows platform
 	exit 0
 fi

--- a/libusb-compat-0.1.5.build.bash
+++ b/libusb-compat-0.1.5.build.bash
@@ -27,8 +27,8 @@ if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw
     wget http://download.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
   fi
   unzip libusb-win32-bin-1.2.6.0.zip
-  mkdir -p $PREFIX/bin/
-  cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll $PREFIX/bin/libusb0.dll
+  #mkdir -p $PREFIX/bin/
+  #cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll $PREFIX/bin/libusb0.dll
   cp libusb-win32-bin-1.2.6.0/include/lusb0_usb.h $PREFIX/include
   cp libusb-win32-bin-1.2.6.0/lib/gcc/libusb.a $PREFIX/lib
   exit 0

--- a/libusb-compat-0.1.5.build.bash
+++ b/libusb-compat-0.1.5.build.bash
@@ -41,7 +41,7 @@ fi
 tar xfv libusb-compat-0.1.5.tar.bz2
 
 cd libusb-compat-0.1.5
-if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw32" ]] ; then
+if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw32" || $CROSS_COMPILE_HOST == "x86_64-w64-mingw32" ]] ; then
   patch -p1 < ../libusb-compat-0.1.5-patches/01-mingw-build.patch
   autoreconf --force --install
 fi

--- a/libusb-compat-0.1.5.build.bash
+++ b/libusb-compat-0.1.5.build.bash
@@ -27,7 +27,8 @@ if [[ $OS == "Msys" || $OS == "Cygwin" || $CROSS_COMPILE_HOST == "i686-w64-mingw
     wget http://download.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
   fi
   unzip libusb-win32-bin-1.2.6.0.zip
-  #cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll $PREFIX/bin/libusb0.dll
+  mkdir -p $PREFIX/bin/
+  cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll $PREFIX/bin/libusb0.dll
   cp libusb-win32-bin-1.2.6.0/include/lusb0_usb.h $PREFIX/include
   cp libusb-win32-bin-1.2.6.0/lib/gcc/libusb.a $PREFIX/lib
   exit 0

--- a/package-avrdude.bash
+++ b/package-avrdude.bash
@@ -65,12 +65,19 @@ elif [[ $OS == "Msys" || $OS == "Cygwin" ]] ; then
   echo you may experience build failure or weird behaviour
   echo *************************************************************
 
-  export PATH=$PATH:/c/MinGW/bin/:/c/cygwin/bin/
-  export CC="mingw32-gcc -m32"
-  export CXX="mingw32-g++ -m32"
-  export TARGET_OS="Windows"
-  OUTPUT_TAG=i686-mingw32
-
+export MACHINE=`uname -m`
+  if [[ $MACHINE == "x86_64" ]] ; then
+    export CC="gcc"
+    export CXX="g++"
+    export TARGET_OS="Windows"
+    OUTPUT_TAG=x86_64-mingw64
+  else
+    export PATH=$PATH:/c/MinGW/bin/:/c/cygwin/bin/
+    export CC="mingw32-gcc -m32"
+    export CXX="mingw32-g++ -m32"
+    export TARGET_OS="Windows"
+    OUTPUT_TAG=i686-mingw32
+  fi
 elif [[ $OS == "Darwin" ]] ; then
 
   export PATH=/opt/local/libexec/gnubin/:/opt/local/bin:$PATH
@@ -92,13 +99,14 @@ rm -rf avrdude-6.3 libusb-1.0.20 libusb-compat-0.1.5 libusb-win32-bin-1.2.6.0 li
 ./libelf-0.8.13.build.bash
 ./libncurses-5.9.build.bash
 ./libhidapi.build.bash
+./libftdi-1.4.build.bash
 ./avrdude-6.3.build.bash
 
 # if producing a windows build, compress as zip and
 # copy *toolchain-precompiled* content to any folder containing a .exe
 if [[ ${OUTPUT_TAG} == *"mingw"* ]] ; then
 
-  cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll objdir/bin/libusb0.dll
+  #cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll objdir/bin/libusb0.dll
   rm -f avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.zip
   cp -a objdir avrdude
   zip -r avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.zip avrdude/bin/ avrdude/etc/avrdude.conf

--- a/package-avrdude.bash
+++ b/package-avrdude.bash
@@ -27,6 +27,13 @@ if [[ $CROSS_COMPILE == "mingw" ]] ; then
   export CROSS_COMPILE_HOST="i686-w64-mingw32"
   export TARGET_OS="Windows"
   OUTPUT_TAG=i686-w64-mingw32
+elif [[ $CROSS_COMPILE == "mingw64" ]] ; then
+
+  export CC="x86_64-w64-mingw32-gcc"
+  export CXX="x86_64-w64-mingw32-g++"
+  export CROSS_COMPILE_HOST="x86_64-w64-mingw32"
+  export TARGET_OS="Windows"
+  OUTPUT_TAG=x86_64-w64-mingw32
 
 elif [[ $CROSS_COMPILE == "arm64-cross" ]] ; then
   export CC="aarch64-linux-gnu-gcc"
@@ -109,14 +116,16 @@ if [[ ${OUTPUT_TAG} == *"mingw"* ]] ; then
   #cp libusb-win32-bin-1.2.6.0/bin/x86/libusb0_x86.dll objdir/bin/libusb0.dll
   rm -f avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.zip
   cp -a objdir avrdude
-  zip -r avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.zip avrdude/bin/ avrdude/etc/avrdude.conf
+  mkdir -p dist/
+  zip -r dist/avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.zip avrdude/bin/ avrdude/etc/avrdude.conf
   rm -r avrdude
 
 else
 
   rm -f avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.tar.bz2
   cp -a objdir avrdude
-  tar -cjvf avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.tar.bz2 avrdude/bin/avrdude avrdude/etc/avrdude.conf
+  mkdir -p dist/
+  tar -cjvf dist/avrdude-${OUTPUT_VERSION}-${OUTPUT_TAG}.tar.bz2 avrdude/bin/avrdude avrdude/etc/avrdude.conf
   rm -r avrdude
 
 fi


### PR DESCRIPTION
Add libftdi support.

It is very useful if someone only have one arduino which have a broken bootloader.

Patch 01 is fix a bug which will close the ftdi usb handle before the reader thread closed.